### PR TITLE
Support for HLS source type

### DIFF
--- a/src/shaka.js
+++ b/src/shaka.js
@@ -172,7 +172,7 @@ Shaka.isSupported = function() {
 
 Shaka.canPlaySource = function(source, tech) {
 
-  const dashTypeRE = /^application\/dash\+xml/i;
+  const dashTypeRE = /^(application\/dash\+xml|application\/x-mpegURL)/i;
 
   if (dashTypeRE.test(source.type)) {
     return 'probably';


### PR DESCRIPTION
This pull request simply changes the regex that checks the source.type, allowing for the HLS (.m3u8) mime type "application/x-mpegURL" to be used.

Currently if you are trying to stream in HLS .m3u8 you can specify the type as dash "application/dash+xml" and it works just fine... even though it's the wrong mime type. This pull requests allows to specify the correct mime type for HLS streams.

Tested with a private streams and it works.